### PR TITLE
twilio-common-ios updates for IPv6 compatibility

### DIFF
--- a/TwilioCommon/0.3.2/TwilioCommon.podspec
+++ b/TwilioCommon/0.3.2/TwilioCommon.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name         = "TwilioCommon"
+  s.version      = "0.3.2"
+  s.summary      = "Twilio Common"
+  s.description  = "Shared components for Twilio mobile SDKs."
+  s.homepage     = "http://www.twilio.com/"
+  s.platform     = :ios, "8.1"
+  s.license      = { 
+    :type => "Commercial", 
+    :text => "Copyright 2011-2016 Twilio. All rights reserved. Use of this software is subject to the terms and conditions of the Twilio Terms of Service located at http://www.twilio.com/legal/tos"
+  }
+  s.author       = { "Twilio" => "help@twilio.com" }
+  s.source       = { :http    => "https://media.twiliocdn.com/sdk/ios/common/releases/0.3.2/twilio-common-ios-0.3.2.tar.bz2" }
+  s.libraries             = "c++"
+  s.vendored_frameworks   = "TwilioCommon.framework"
+  s.requires_arc          = true
+end

--- a/TwilioConversationsClient/0.25.1/TwilioConversationsClient.podspec
+++ b/TwilioConversationsClient/0.25.1/TwilioConversationsClient.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.vendored_frameworks   = "TwilioConversationsClient.framework"
   s.requires_arc          = true
   s.xcconfig              = { 'OTHER_LDFLAGS' => '-ObjC' }
-  s.dependency "TwilioCommon", "~> 0.3.1"
+  s.dependency "TwilioCommon", "0.3.1"
 end


### PR DESCRIPTION
- added common 0.3.2 to address IPv6 compatibility issues in iOS 10
- temporarily restrict conversations to 0.3.1