### PR TITLE
For Voice 2.0.0-beta8

### DIFF
--- a/TwilioVoice/2.0.0-beta8/TwilioVoice.podspec
+++ b/TwilioVoice/2.0.0-beta8/TwilioVoice.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name         = "TwilioVoice"
+  s.version      = "2.0.0-beta8"
+  s.summary      = "Twilio Voice"
+  s.description  = "Twilio Voice makes it easy to embed VoIP directly into your iOS apps."
+  s.homepage     = "http://www.twilio.com/docs/api/voice-sdk"
+  s.platform     = :ios, "8.1"
+  s.license      = { 
+    :type => "Commercial", 
+    :text => "Copyright © 2011-2017 Twilio, Inc. All rights reserved. Use of this software is subject to the terms and conditions of the Twilio Terms of Service located at http://www.twilio.com/legal/tos"
+  }
+  s.author       = { "Twilio" => "help@twilio.com" }
+  s.source       = { :http    => "https://media.twiliocdn.com/sdk/ios/voice/releases/2.0.0-beta8/twilio-voice-ios-2.0.0-beta8.tar.bz2" }
+  s.vendored_frameworks   = "TwilioVoice.framework"
+  s.requires_arc          = true
+end


### PR DESCRIPTION
Note that with the naming update (~client~), 2.0.0-beta8 will be under `TwilioVoice` now, instead of `TwilioVoiceClient` where previous beta releases are hosted.